### PR TITLE
Create PaymentsApi and expose Invoice's type_of_sale field

### DIFF
--- a/src/Contractors/Contractor.php
+++ b/src/Contractors/Contractor.php
@@ -6,7 +6,7 @@ use JMS\Serializer\Annotation as JMS;
 use Webit\WFirmaSDK\CompanyAccounts\CompanyAccountId;
 use Webit\WFirmaSDK\Entity\DateAwareEntity;
 use Webit\WFirmaSDK\InvoiceDescriptions\InvoiceDescriptionId;
-use Webit\WFirmaSDK\Invoices\PaymentMethod;
+use Webit\WFirmaSDK\Payments\PaymentMethod;
 use Webit\WFirmaSDK\Tags\TagIds;
 use Webit\WFirmaSDK\TranslationLanguages\TranslationLanguageId;
 

--- a/src/Contractors/PaymentSettings.php
+++ b/src/Contractors/PaymentSettings.php
@@ -2,7 +2,7 @@
 
 namespace Webit\WFirmaSDK\Contractors;
 
-use Webit\WFirmaSDK\Invoices\PaymentMethod;
+use Webit\WFirmaSDK\Payments\PaymentMethod;
 
 final class PaymentSettings
 {

--- a/src/Entity/ModuleApiFactory.php
+++ b/src/Entity/ModuleApiFactory.php
@@ -9,6 +9,7 @@ use Webit\WFirmaSDK\InvoiceDeliveries\InvoiceDeliveriesApi;
 use Webit\WFirmaSDK\InvoiceDescriptions\InvoiceDescriptionsApi;
 use Webit\WFirmaSDK\Invoices\InvoicesApi;
 use Webit\WFirmaSDK\Notes\NotesApi;
+use Webit\WFirmaSDK\Payments\PaymentsApi;
 use Webit\WFirmaSDK\Series\SeriesApi;
 use Webit\WFirmaSDK\Tags\TagsApi;
 use Webit\WFirmaSDK\TranslationLanguages\TranslationLanguagesApi;
@@ -86,6 +87,14 @@ class ModuleApiFactory
     public function notesApi()
     {
         return new NotesApi($this->entityApi);
+    }
+
+    /**
+     * @return PaymentsApi
+     */
+    public function paymentsApi()
+    {
+        return new PaymentsApi($this->entityApi);
     }
 
     /**

--- a/src/Expenses/ExpenseId.php
+++ b/src/Expenses/ExpenseId.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webit\WFirmaSDK\Expenses;
+
+use Webit\WFirmaSDK\Entity\AbstractEntityId;
+use JMS\Serializer\Annotation as JMS;
+
+/**
+ * @JMS\XmlRoot("expense")
+ */
+final class ExpenseId extends AbstractEntityId
+{
+}

--- a/src/Invoices/Invoice.php
+++ b/src/Invoices/Invoice.php
@@ -7,6 +7,7 @@ use Webit\WFirmaSDK\Contractors\ContractorId;
 use Webit\WFirmaSDK\Entity\DateAwareEntity;
 use Webit\WFirmaSDK\Series\SeriesId;
 use JMS\Serializer\Annotation as JMS;
+use Webit\WFirmaSDK\Payments\PaymentMethod;
 use Webit\WFirmaSDK\Tags\TagIds;
 
 /**

--- a/src/Invoices/Invoice.php
+++ b/src/Invoices/Invoice.php
@@ -315,6 +315,15 @@ final class Invoice extends DateAwareEntity
     private $template;
 
     /**
+     * @var string
+     * @JMS\Type("string")
+     * @JMS\SerializedName("type_of_sale")
+     * @JMS\XmlElement(cdata=false)
+     * @JMS\Groups({"request", "response"})
+     */
+    private $typeOfSale;
+
+    /**
      * @var int
      * @JMS\Type("integer")
      * @JMS\SerializedName("auto_send")
@@ -941,6 +950,41 @@ final class Invoice extends DateAwareEntity
     public function correction()
     {
         return new Correction($this->correctionType, $this->corrections, $this->formalDataCorrections);
+    }
+
+    /**
+     * @return TypeOfSale[]
+     */
+    public function typesOfSale()
+    {
+        $typesOfSale = json_decode($this->typeOfSale, true);
+        $typesOfSale = array_map(
+            function($typeOfSale) {
+                return TypeOfSale::fromString($typeOfSale);
+            },
+            is_array($typesOfSale) ? $typesOfSale : []
+        );
+        sort($typesOfSale);
+        return array_values($typesOfSale);
+    }
+
+    /**
+     * @param TypeOfSale[] $typesOfSale
+     */
+    public function changeTypesOfSale(TypeOfSale ...$typesOfSale)
+    {
+        $typesOfSale = array_unique(
+            array_map(
+                function($typeOfSale) {
+                    return (string)$typeOfSale;
+                },
+                $typesOfSale
+            )
+        );
+        sort($typesOfSale);
+        $typesOfSale = array_values($typesOfSale);
+
+        $this->typeOfSale = count($typesOfSale) > 0 ? json_encode($typesOfSale) : '';
     }
 
     /**

--- a/src/Invoices/Invoice.php
+++ b/src/Invoices/Invoice.php
@@ -802,12 +802,15 @@ final class Invoice extends DateAwareEntity
 
     /**
      * @param Payment $payment
+     * @return Invoice
      */
     public function changePayment(Payment $payment)
     {
         $this->paymentMethod = $payment->paymentMethod();
         $this->paymentDate = $payment->paymentDate();
         $this->alreadyPaidInitial = $payment->alreadyPaidInitial();
+
+        return $this;
     }
 
     /**

--- a/src/Invoices/Payment.php
+++ b/src/Invoices/Payment.php
@@ -2,6 +2,8 @@
 
 namespace Webit\WFirmaSDK\Invoices;
 
+use Webit\WFirmaSDK\Payments\PaymentMethod;
+
 final class Payment
 {
     /** @var PaymentMethod */

--- a/src/Invoices/TypeOfSale.php
+++ b/src/Invoices/TypeOfSale.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Webit\WFirmaSDK\Invoices;
+
+final class TypeOfSale
+{
+    /** @var string */
+    private $typeOfSale;
+
+    /**
+     * @param array $typeOfSale
+     */
+    private function __construct($typeOfSale)
+    {
+        $this->typeOfSale = (string)$typeOfSale;
+    }
+
+    /**
+     * @return TypeOfSale
+     */
+    public static function EE()
+    {
+        return new self('EE');
+    }
+
+    /**
+     * @return TypeOfSale
+     */
+    public static function SW()
+    {
+        return new self('SW');
+    }
+
+    /**
+     * @param string $typeOfSale
+     * @return TypeOfSale
+     * @internal
+     */
+    public static function fromString($typeOfSale)
+    {
+        return new self($typeOfSale);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __toString()
+    {
+        return $this->typeOfSale;
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -147,6 +147,14 @@ final class Module
     /**
      * @return Module
      */
+    public static function payments()
+    {
+        return self::module('payments');
+    }
+
+    /**
+     * @return Module
+     */
     public static function notes()
     {
         return self::module('notes');
@@ -293,6 +301,18 @@ final class Module
             'invoice_deliveries',
             'invoice_delivery',
             'Webit\WFirmaSDK\InvoiceDeliveries\InvoiceDelivery',
+            array(
+                'find',
+                'get',
+                'add',
+                'delete'
+            )
+        );
+
+        self::$modules['payments'] = new self(
+            'payments',
+            'payment',
+            'Webit\WFirmaSDK\Payments\Payment',
             array(
                 'find',
                 'get',

--- a/src/PaymentCashboxes/PaymentCashboxId.php
+++ b/src/PaymentCashboxes/PaymentCashboxId.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webit\WFirmaSDK\PaymentCashboxes;
+
+use Webit\WFirmaSDK\Entity\AbstractEntityId;
+use JMS\Serializer\Annotation as JMS;
+
+/**
+ * @JMS\XmlRoot("payment_cashbox")
+ */
+final class PaymentCashboxId extends AbstractEntityId
+{
+}

--- a/src/Payments/Payment.php
+++ b/src/Payments/Payment.php
@@ -1,0 +1,461 @@
+<?php
+
+namespace Webit\WFirmaSDK\Payments;
+
+use Webit\WFirmaSDK\Contractors\ContractorId;
+use Webit\WFirmaSDK\Entity\DateAwareEntity;
+use Webit\WFirmaSDK\Expenses\ExpenseId;
+use Webit\WFirmaSDK\Invoices\Invoice;
+use Webit\WFirmaSDK\Invoices\InvoiceId;
+use Webit\WFirmaSDK\Invoices\PaymentCurrency;
+use Webit\WFirmaSDK\PaymentCashboxes\PaymentCashboxId;
+use Webit\WFirmaSDK\Series\SeriesId;
+use Webit\WFirmaSDK\Tags\TagIds;
+use JMS\Serializer\Annotation as JMS;
+
+/**
+ * @JMS\XmlRoot("payment")
+ */
+final class Payment extends DateAwareEntity {
+    /**
+     * @var string
+     * @JMS\Type("string")
+     * @JMS\SerializedName("object_name")
+     * @JMS\Groups({"request", "response"})
+     */
+    private $objectName;
+
+    /**
+     * @var InvoiceId|ExpenseId
+     * @JMS\Type("int")
+     * @JMS\SerializedName("object_id")
+     * @JMS\Groups({"request", "response"})
+     */
+    private $objectId;
+
+    /**
+     * @var float
+     * @JMS\Type("double")
+     * @JMS\SerializedName("value")
+     * @JMS\Groups({"request", "response"})
+     */
+    private $value;
+
+    /**
+     * @var float
+     * @JMS\Type("double")
+     * @JMS\SerializedName("social")
+     * @JMS\Groups({"response"})
+     */
+    private $social;
+
+    /**
+     * @var float
+     * @JMS\Type("double")
+     * @JMS\SerializedName("health")
+     * @JMS\Groups({"response"})
+     */
+    private $health;
+
+    /**
+     * @var float
+     * @JMS\Type("double")
+     * @JMS\SerializedName("labor_fund")
+     * @JMS\Groups({"response"})
+     */
+    private $laborFund;
+
+    /**
+     * @var float
+     * @JMS\Type("double")
+     * @JMS\SerializedName("transitional_retiring_fund")
+     * @JMS\Groups({"response"})
+     */
+    private $transitionalRetiringFund;
+
+    /**
+     * @var \DateTime
+     * @JMS\Type("DateTime<'Y-m-d'>")
+     * @JMS\SerializedName("date")
+     * @JMS\XmlElement(cdata=false)
+     * @JMS\Groups({"request", "response"})
+     */
+    private $date;
+
+    /**
+     * @var int
+     * @JMS\Type("int")
+     * @JMS\SerializedName("initial")
+     * @JMS\Groups({"response"})
+     */
+    private $initial;
+
+    /**
+     * @var string
+     * @JMS\Type("string")
+     * @JMS\SerializedName("type")
+     * @JMS\XmlElement(cdata=false)
+     * @JMS\Groups({"response"})
+     */
+    private $type;
+
+    /**
+     * @var string
+     * @JMS\Type("string")
+     * @JMS\SerializedName("payment_method")
+     * @JMS\XmlElement(cdata=false)
+     * @JMS\Groups({"request", "response"})
+     */
+    private $paymentMethod;
+
+    /**
+     * @var string
+     * @JMS\Type("string")
+     * @JMS\SerializedName("payment_type")
+     * @JMS\XmlElement(cdata=false)
+     * @JMS\Groups({"request", "response"})
+     */
+    private $paymentType;
+
+    /**
+     * @var string
+     * @JMS\Type("string")
+     * @JMS\SerializedName("account")
+     * @JMS\Groups({"request", "response"})
+     */
+    private $account;
+
+    /**
+     * @var float
+     * @JMS\Type("double")
+     * @JMS\SerializedName("value_pln")
+     * @JMS\Groups({"request", "response"})
+     */
+    private $valuePln;
+
+    /**
+     * @var float
+     * @JMS\Type("double")
+     * @JMS\SerializedName("currency_exchange")
+     * @JMS\Groups({"response"})
+     */
+    private $currencyExchange;
+
+    /**
+     * @var string
+     * @JMS\Type("string")
+     * @JMS\SerializedName("currency_label")
+     * @JMS\Groups({"response"})
+     */
+    private $currencyLabel;
+
+    /**
+     * @var \DateTime
+     * @JMS\Type("DateTime<'Y-m-d'>")
+     * @JMS\SerializedName("currency_date")
+     * @JMS\Groups({"response"})
+     */
+    private $currency_date;
+
+    /**
+     * @var int
+     * @JMS\Type("integer")
+     * @JMS\SerializedName("notes")
+     * @JMS\XmlElement(cdata=false)
+     * @JMS\Groups({"request", "response"})
+     */
+    private $notes;
+
+    /**
+     * @var TagIds
+     * @JMS\Type("Webit\WFirmaSDK\Tags\TagIds")
+     * @JMS\SerializedName("tags")
+     * @JMS\Groups({"request", "response"})
+     */
+    private $tags;
+
+    /**
+     * @var InvoiceId
+     * @JMS\Type("Webit\WFirmaSDK\Invoices\InvoiceId")
+     * @JMS\SerializedName("invoice")
+     * @JMS\XmlElement(cdata=false)
+     * @JMS\Groups({"response"})
+     */
+    private $invoiceId;
+
+    /**
+     * @var ExpenseId
+     * @JMS\Type("Webit\WFirmaSDK\Expenses\ExpenseId")
+     * @JMS\SerializedName("expense")
+     * @JMS\XmlElement(cdata=false)
+     * @JMS\Groups({"response"})
+     */
+    private $expenseId;
+
+    /**
+     * @var SeriesId
+     * @JMS\Type("Webit\WFirmaSDK\Series\SeriesId")
+     * @JMS\SerializedName("series")
+     * @JMS\XmlElement(cdata=false)
+     * @JMS\Groups({"response"})
+     */
+    private $seriesId;
+
+    /**
+     * @var PaymentCashboxId
+     * @JMS\Type("Webit\WFirmaSDK\PaymentCashboxes\PaymentCashboxId")
+     * @JMS\SerializedName("payment_cashbox")
+     * @JMS\XmlElement(cdata=false)
+     * @JMS\Groups({"response"})
+     */
+    private $paymentCashboxId;
+
+    /**
+     * @var ContractorId
+     * @JMS\Type("Webit\WFirmaSDK\Contractors\ContractorId")
+     * @JMS\SerializedName("contractor")
+     * @JMS\XmlElement(cdata=false)
+     * @JMS\Groups({"response"})
+     */
+    private $contractorId;
+
+    /**
+     * Payment constructor.
+     * @param string $objectName
+     * @param string $objectId
+     * @param float $value
+     * @param \DateTimeInterface|null $date
+     * @param PaymentMethod|null $paymentMethod
+     * @param PaymentCurrency|null $paymentCurrency
+     * @param PaymentCashboxId|null $cashboxId
+     * @param TagIds|null $tags
+     */
+    private function __construct(
+        $objectName,
+        $objectId,
+        $value,
+        \DateTimeInterface $date = null,
+        PaymentMethod $paymentMethod = null,
+        PaymentCurrency $paymentCurrency = null,
+        PaymentCashboxId $cashboxId = null,
+        TagIds $tags = null
+    ) {
+        $this->objectName = (string)$objectName;
+        $this->objectId = (string)$objectId;
+        $this->value = (float)$value;
+        $this->changeDate($date);
+        $this->changePaymentMethod($paymentMethod);
+        $this->changePaymentCurrency($paymentCurrency);
+        $this->changePaymentCashboxId($cashboxId);
+        $this->tags = $tags;
+    }
+
+    /**
+     * @param Invoice $invoice
+     * @param float $value
+     * @param \DateTimeInterface|null $date
+     * @param PaymentMethod|null $paymentMethod
+     * @param PaymentCurrency|null $paymentCurrency
+     * @param PaymentCashboxId|null $cashboxId
+     * @param TagIds|null $tags
+     * @return Payment
+     */
+    public static function forInvoice(
+        Invoice $invoice,
+        $value,
+        \DateTimeInterface $date = null,
+        PaymentMethod $paymentMethod = null,
+        PaymentCurrency $paymentCurrency = null,
+        PaymentCashboxId $cashboxId = null,
+        TagIds $tags = null
+    ) {
+        return new self(
+            'invoice',
+            $invoice->id(),
+            $value,
+            $date,
+            $paymentMethod,
+            $paymentCurrency,
+            $cashboxId,
+            $tags
+        );
+    }
+
+    /**
+     * @param InvoiceId $invoice
+     * @param float $value
+     * @param \DateTimeInterface|null $date
+     * @param PaymentMethod|null $paymentMethod
+     * @param PaymentCurrency|null $paymentCurrency
+     * @param PaymentCashboxId|null $cashboxId
+     * @param TagIds|null $tags
+     * @return Payment
+     */
+    public static function forInvoiceOfId(
+        InvoiceId $invoiceId,
+        $value,
+        \DateTimeInterface $date = null,
+        PaymentMethod $paymentMethod = null,
+        PaymentCurrency $paymentCurrency = null,
+        PaymentCashboxId $cashboxId = null,
+        TagIds $tags = null
+    ) {
+        return new self(
+            'invoice',
+            $invoiceId,
+            $value,
+            $date,
+            $paymentMethod,
+            $paymentCurrency,
+            $cashboxId,
+            $tags
+        );
+    }
+
+    /**
+     * @param Invoice $invoice
+     * @param float $value
+     * @param \DateTimeInterface|null $date
+     * @param PaymentMethod|null $paymentMethod
+     * @param PaymentCurrency|null $paymentCurrency
+     * @param PaymentCashboxId|null $cashboxId
+     * @param TagIds|null $tags
+     * @return Payment
+     */
+    public static function forExpenseOfId(
+        ExpenseId $expenseId,
+        $value,
+        \DateTimeInterface $date = null,
+        PaymentMethod $paymentMethod = null,
+        PaymentCurrency $paymentCurrency = null,
+        PaymentCashboxId $cashboxId = null,
+        TagIds $tags = null
+    ) {
+        return new self(
+            'expense',
+            $expenseId,
+            $value,
+            $date,
+            $paymentMethod,
+            $paymentCurrency,
+            $cashboxId,
+            $tags
+        );
+    }
+
+    /**
+     * @return null|\Webit\WFirmaSDK\Entity\EntityId|PaymentId
+     */
+    public function id()
+    {
+        return PaymentId::create($this->plainId());
+    }
+
+    /**
+     * @return float
+     */
+    public function value()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param float $value
+     * @return Payment
+     */
+    public function changeValue(float $value)
+    {
+        $this->value = (float)$value;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function date()
+    {
+        $date = \DateTimeImmutable::createFromInterface($this->date);
+        return $date->setTime(0, 0);
+    }
+
+    /**
+     * @param \DateTimeInterface $date
+     * @return Payment
+     */
+    public function changeDate(\DateTimeInterface $date = null)
+    {
+        $this->date = \DateTime::createFromInterface($date ?: new \DateTime());
+        return $this;
+    }
+
+    /**
+     * @return PaymentMethod
+     */
+    public function paymentMethod()
+    {
+        return PaymentMethod::fromString($this->paymentMethod);
+    }
+
+    /**
+     * @param PaymentMethod $paymentMethod
+     * @return Payment
+     */
+    public function changePaymentMethod(PaymentMethod $paymentMethod = null)
+    {
+        $this->paymentMethod = (string)($paymentMethod ?: PaymentMethod::cash());
+        return $this;
+    }
+
+    /**
+     * @return PaymentCurrency|null
+     */
+    public function paymentCurrency()
+    {
+        if ($this->account === 'pln') {
+            return PaymentCurrency::pln($this->valuePln);
+        } elseif ($this->account === 'currency') {
+            return PaymentCurrency::foreign();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param PaymentCurrency|null $paymentCurrency
+     * @return Payment
+     */
+    public function changePaymentCurrency(PaymentCurrency $paymentCurrency = null)
+    {
+        if ($paymentCurrency) {
+            $this->account = $paymentCurrency->isCurrencyPayment() ? 'currenct' : 'pln';
+            $this->valuePln = $paymentCurrency->amountPln();
+        } else {
+            $this->account = null;
+            $this->valuePln = null;
+        }
+        return $this;
+    }
+
+    /**
+     * @return PaymentCashboxId|null $cashboxId
+     */
+    public function paymentCashboxId()
+    {
+        return PaymentCashboxId::create($this->paymentCashboxId);
+    }
+
+    /**
+     * @param PaymentCashboxId|null $cashboxId
+     * @return Payment
+     */
+    public function changePaymentCashboxId(PaymentCashboxId $paymentCashboxId = null)
+    {
+        if ($paymentCashboxId) {
+            $this->paymentType = 'cashbox';
+            $this->paymentCashboxId = (string)$paymentCashboxId;
+        } else {
+            $this->paymentType = 'normal';
+            $this->paymentCashboxId = null;
+        }
+        return $this;
+    }
+}

--- a/src/Payments/PaymentCurrency.php
+++ b/src/Payments/PaymentCurrency.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Webit\WFirmaSDK\Invoices;
+
+final class PaymentCurrency
+{
+    /** @var bool */
+    private $currencyPayment;
+
+    /** @var float */
+    private $amountPln;
+
+    /**
+     * @param float|null $amountPln
+     * @internal
+     */
+    private function __construct(
+        $amountPln = null
+    ) {
+        if($amountPln === null) {
+            $this->currencyPayment = TRUE;
+            $this->amountPln = null;
+        } else {
+            $this->currencyPayment = FALSE;
+            $this->amountPln = (float)$amountPln;
+        }
+    }
+
+
+    /**
+     * @param float $amount
+     * @return PaymentCurrency
+     */
+    public static function pln(float $amount)
+    {
+        return new self($amount);
+    }
+
+    /**
+     * @return PaymentCurrency
+     */
+    public static function foreign()
+    {
+        return new self();
+    }
+
+    /**
+     * @return PaymentMethod
+     */
+    public function isCurrencyPayment()
+    {
+        return $this->currencyPayment;
+    }
+
+    public function amountPln()
+    {
+        return $this->amountPln;
+    }
+}

--- a/src/Payments/PaymentId.php
+++ b/src/Payments/PaymentId.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webit\WFirmaSDK\Payments;
+
+use Webit\WFirmaSDK\Entity\AbstractEntityId;
+use JMS\Serializer\Annotation as JMS;
+
+/**
+ * @JMS\XmlRoot("payment")
+ */
+final class PaymentId extends AbstractEntityId
+{
+}

--- a/src/Payments/PaymentMethod.php
+++ b/src/Payments/PaymentMethod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webit\WFirmaSDK\Invoices;
+namespace Webit\WFirmaSDK\Payments;
 
 final class PaymentMethod
 {

--- a/src/Payments/PaymentsApi.php
+++ b/src/Payments/PaymentsApi.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Webit\WFirmaSDK\Payments;
+
+use Webit\WFirmaSDK\Entity\EntityApi;
+use Webit\WFirmaSDK\Module;
+use Webit\WFirmaSDK\Entity\Entity;
+
+class PaymentsApi
+{
+    /** @var EntityApi */
+    private $entityApi;
+
+    /**
+     * @param EntityApi $entityApi
+     */
+    public function __construct(EntityApi $entityApi)
+    {
+        $this->entityApi = $entityApi;
+    }
+
+    /**
+     * @param Payment $payment
+     * @return Payment|Entity
+     */
+    public function add(Payment $payment)
+    {
+        return $this->entityApi->add($payment);
+    }
+
+    /**
+     * @param Payment $payment
+     * @return Payment|Entity
+     */
+    public function edit(Payment $payment)
+    {
+        return $this->entityApi->edit($payment);
+    }
+
+    /**
+     * @param PaymentId $id
+     */
+    public function delete(PaymentId $id)
+    {
+        $this->entityApi->delete($id->id(), Module::payments());
+    }
+
+    /**
+     * @param PaymentId $id
+     * @return Payment|Entity
+     */
+    public function get(PaymentId $id)
+    {
+        return $this->entityApi->get($id->id(), Module::payments());
+    }
+}

--- a/tests/Contractors/ContractorsApiIntegrationTest.php
+++ b/tests/Contractors/ContractorsApiIntegrationTest.php
@@ -4,7 +4,7 @@ namespace Webit\WFirmaSDK\Contractors;
 
 use Webit\WFirmaSDK\Entity\AbstractApiTestCase;
 use Webit\WFirmaSDK\Entity\Exception\NotFoundException;
-use Webit\WFirmaSDK\Invoices\PaymentMethod;
+use Webit\WFirmaSDK\Payments\PaymentMethod;
 use Webit\WFirmaSDK\Module;
 use Webit\WFirmaSDK\TranslationLanguages\TranslationLanguageId;
 

--- a/tests/Invoices/InvoicesApiIntegrationTest.php
+++ b/tests/Invoices/InvoicesApiIntegrationTest.php
@@ -9,6 +9,7 @@ use Webit\WFirmaSDK\Entity\AbstractApiTestCase;
 use Webit\WFirmaSDK\Contractors\Contractor;
 use Webit\WFirmaSDK\Contractors\InvoiceAddress;
 use Webit\WFirmaSDK\Entity\Exception\NotFoundException;
+use Webit\WFirmaSDK\Payments\PaymentMethod;
 use Webit\WFirmaSDK\Series\SeriesId;
 
 class InvoicesApiIntegrationTest extends AbstractApiTestCase

--- a/tests/Payments/PaymentsApiIntegrationTest.php
+++ b/tests/Payments/PaymentsApiIntegrationTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Webit\WFirmaSDK\Payments;
+
+use DateInterval;
+use Webit\WFirmaSDK\Contractors\ContactAddress;
+use Webit\WFirmaSDK\Contractors\ContractorsApi;
+use Webit\WFirmaSDK\Entity\AbstractApiTestCase;
+use Webit\WFirmaSDK\Contractors\Contractor;
+use Webit\WFirmaSDK\Contractors\InvoiceAddress;
+use Webit\WFirmaSDK\Entity\Exception\NotFoundException;
+use Webit\WFirmaSDK\Invoices\Invoice;
+use Webit\WFirmaSDK\Invoices\InvoicesApi;
+use Webit\WFirmaSDK\Invoices\InvoicesContent;
+use Webit\WFirmaSDK\Invoices\Type;
+use Webit\WFirmaSDK\Series\SeriesId;
+
+class PaymentsApiIntegrationTest extends AbstractApiTestCase
+{
+    /** @var PaymentsApi */
+    private $api;
+
+    /** @var Payment[] */
+    private $payments = array();
+
+    /** @var Invoices[] */
+    private $invoices = array();
+    
+    /** @var Contractors[] */
+    private $contractors = array();
+
+    protected function setUp()
+    {
+        $this->api = new PaymentsApi($this->entityApi());
+    }
+
+    protected function tearDown()
+    {
+        foreach($this->payments as $payment) {
+            $this->api->delete($payment->id());
+        }
+
+        $invoicesApi = new InvoicesApi($this->entityApi());
+        foreach ($this->invoices as $invoice) {
+            $invoicesApi->delete($invoice->id());
+        }
+
+        $contractorsApi = new ContractorsApi($this->entityApi());
+        foreach ($this->contractors as $contractor) {
+            $contractorsApi->delete($contractor->id());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function testAdd()
+    {
+        $this->payments[] = $createdPayment = $this->api->add(
+            $invoice = $this->newPayment()
+        );
+
+        $this->assertInstanceOf('Webit\WFirmaSDK\Payments\Payment', $createdPayment);
+    }
+
+
+    /**
+     * @test
+     */
+    public function testEdit()
+    {
+        $this->payments[] = $createdPayment = $this->api->add(
+            $payment = $this->newPayment()
+        );
+
+        $this->assertInstanceOf('Webit\WFirmaSDK\Payments\Payment', $createdPayment);
+
+        /** @var Payment $createdPayment */
+        $createdPayment->value(0.01);
+        $createdPayment->changeDate(date_create('now +1 day'));
+        $createdPayment->changePaymentMethod(PaymentMethod::paymentCard());
+
+        $this->api->edit($createdPayment);
+    }
+
+    /**
+     * @test
+     */
+    public function testDelete()
+    {
+        $createdPayment = $this->api->add(
+            $payment = $this->newPayment()
+        );
+        $this->api->delete($createdPayment->id());
+
+        try {
+            $this->api->get($createdPayment->id());
+        } catch (NotFoundException $e) {
+            $this->assertTrue(true);
+            return;
+        }
+
+        $this->assertTrue(false, 'Payment still exists.');
+    }
+
+    /**
+     * @test
+     */
+    public function testGet()
+    {
+        $createdPayment = $this->api->add($this->newPayment());
+
+        $payment = $this->api->get($createdPayment->id());
+
+        $this->assertInstanceOf('Webit\WFirmaSDK\Payments\Payment', $payment);
+        $this->assertEquals($createdPayment->id(), $payment->id());
+    }
+
+    /**
+     * @return Payment
+     */
+    private function newPayment()
+    {
+        /** @var Invoice $invoice */
+        $invoice = $this->createInvoice();
+        return Payment::forInvoice(
+            $invoice,
+            $invoice->totals()->original(),
+            null,
+            PaymentMethod::transfer()
+        );
+    }
+
+    /**
+     * @return Invoice
+     */
+    private function newInvoice(SeriesId $seriesId = null)
+    {
+        $invoice = Invoice::forContractor(
+            $this->newContractor(),
+            \Webit\WFirmaSDK\Invoices\Payment::create(
+                PaymentMethod::transfer()
+            ),
+            Type::vat(),
+            $seriesId,
+            date_create('now')
+        );
+
+        $invoice->addInvoiceContent(
+            $this->newInvoiceContent()
+        );
+
+        $invoice->addInvoiceContent(
+            $this->newInvoiceContent()
+        );
+
+        return $invoice;
+    }
+
+    /**
+     * @return InvoicesContent
+     */
+    private function newInvoiceContent()
+    {
+        return InvoicesContent::fromName(
+            $this->faker()->colorName,
+            'szt.',
+            mt_rand(1, 5),
+            $this->faker()->randomFloat(2, 100, 1000),
+            23
+        );
+    }
+
+    /**
+     * @return Invoice|\Webit\WFirmaSDK\Entity\Entity
+     */
+    private function createInvoice()
+    {
+        $i = new InvoicesApi($this->entityApi());
+        return $this->invoices[] = $i->add($this->newInvoice());
+    }
+
+    /**
+     * @return Contractor
+     */
+    private function newContractor()
+    {
+        return new Contractor(
+            $this->faker()->company,
+            null,
+            '1234563218',
+            null,
+            new InvoiceAddress(
+                $this->faker()->streetAddress,
+                $this->faker()->postcode,
+                $this->faker()->city,
+                'PL'
+            ),
+            new ContactAddress(
+                $this->faker()->company,
+                $this->faker()->streetAddress,
+                $this->faker()->postcode,
+                $this->faker()->city,
+                'PL',
+                $this->faker()->name
+            )
+        );
+    }
+}

--- a/tests/Payments/resources/add.xml
+++ b/tests/Payments/resources/add.xml
@@ -1,0 +1,972 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <invoices>
+        <invoice>
+            <contractor>
+                <name>Spółdzielnia Szulc</name>
+                <tax_id_type>nip</tax_id_type>
+                <nip>1234563218</nip>
+                <street><![CDATA[Rodzinna 15/85]]></street>
+                <zip>87-807</zip>
+                <city>Świdwin</city>
+                <country>PL</country>
+                <different_contact_address>1</different_contact_address>
+                <contact_name>Błaszczyk</contact_name>
+                <contact_street>Niemcewicza Juliana Ursyna 08A/64</contact_street>
+                <contact_zip>57-833</contact_zip>
+                <contact_city>Łowicz</contact_city>
+                <contact_country>PL</contact_country>
+                <contact_person>Urszula Sobczak</contact_person>
+                <buyer>1</buyer>
+                <seller>0</seller>
+            </contractor>
+            <paymentmethod>transfer</paymentmethod>
+            <paymentdate>2018-02-13</paymentdate>
+            <date>2018-01-23</date>
+            <type>normal</type>
+            <auto_send>0</auto_send>
+            <auto_send_postivo>0</auto_send_postivo>
+            <auto_sms>0</auto_sms>
+            <schema_bill>0</schema_bill>
+            <schema_canceled>0</schema_canceled>
+            <invoicecontents>
+                <invoicecontent>
+                    <name>DarkSlateBlue</name>
+                    <unit>szt.</unit>
+                    <count>4</count>
+                    <price>657.95</price>
+                    <vat>23</vat>
+                </invoicecontent>
+                <invoicecontent>
+                    <name>Aquamarine</name>
+                    <unit>szt.</unit>
+                    <count>1</count>
+                    <price>892.05</price>
+                    <vat>23</vat>
+                </invoicecontent>
+            </invoicecontents>
+            <series>
+                <id>5415136</id>
+            </series>
+        </invoice>
+    </invoices>
+</api>  {"request":"/invoices/add"} []
+        [2018-01-26 14:14:30] API.DEBUG: <?xml version="1.0" encoding="UTF-8"?> <api>
+<invoices>
+    <invoice>
+        <id>32361257</id>
+        <interest_status></interest_status>
+        <warehouse_type>extended</warehouse_type>
+        <paymentmethod>transfer</paymentmethod>
+        <paymentdate>2018-02-13</paymentdate>
+        <paymentstate>unpaid</paymentstate>
+        <disposaldate_format>day</disposaldate_format>
+        <disposaldate_empty>0</disposaldate_empty>
+        <disposaldate>2018-01-26</disposaldate>
+        <date>2018-01-23</date>
+        <total>4334.34</total>
+        <total_composed>4334.34</total_composed>
+        <alreadypaid>0.00</alreadypaid>
+        <alreadypaid_initial></alreadypaid_initial>
+        <remaining>4334.34</remaining>
+        <number>4</number>
+        <day>23</day>
+        <month>1</month>
+        <year>2018</year>
+        <day_year>23</day_year>
+        <fullnumber>FV/I/Test/2018/4</fullnumber>
+        <semitemplatenumber>FV/I/Test/2018/[numer]</semitemplatenumber>
+        <type>normal</type>
+        <correction_type></correction_type>
+        <corrections>0</corrections>
+        <formal_data_corrections>0</formal_data_corrections>
+        <currency>PLN</currency>
+        <currency_exchange>1.0000</currency_exchange>
+        <currency_label></currency_label>
+        <currency_date></currency_date>
+        <price_currency_exchange>1.0000</price_currency_exchange>
+        <good_price_group_currency_exchange>1.0000</good_price_group_currency_exchange>
+        <auto_send_postivo>0</auto_send_postivo>
+        <auto_send>0</auto_send>
+        <auto_sms>0</auto_sms>
+        <account_type></account_type>
+        <account_date></account_date>
+        <template>3</template>
+        <description></description>
+        <header></header>
+        <footer></footer>
+        <user_name></user_name>
+        <schema>normal</schema>
+        <schema_vat_cashbox>0</schema_vat_cashbox>
+        <schema_vat_cashbox_limit></schema_vat_cashbox_limit>
+        <schema_vat_cashbox_small_taxpayer>0</schema_vat_cashbox_small_taxpayer>
+        <schema_bill>0</schema_bill>
+        <schema_receipt_book>0</schema_receipt_book>
+        <schema_cancelled>0</schema_cancelled>
+        <margin_tax_schema></margin_tax_schema>
+        <margin_description_schema></margin_description_schema>
+        <register_description></register_description>
+        <income_lumpcode></income_lumpcode>
+        <income_correction>0</income_correction>
+        <bill_legal_description></bill_legal_description>
+        <netto>3523.85</netto>
+        <tax>810.49</tax>
+        <receipt_fiscal_printed>0</receipt_fiscal_printed>
+        <vindicat_sent>0</vindicat_sent>
+        <invipay_sent>0</invipay_sent>
+        <courier_shipments>0</courier_shipments>
+        <hash>49d94ee5fa391adcd2d4c5dd29763c66</hash>
+        <id_external></id_external>
+        <tags></tags>
+        <notes>0</notes>
+        <documents>0</documents>
+        <created>2018-01-26 15:12:56</created>
+        <modified>2018-01-26 15:12:56</modified>
+        <price_type>netto</price_type>
+        <series>
+            <id>5415136</id>
+        </series>
+        <contractor>
+            <id>0</id>
+        </contractor>
+        <contractor_detail>
+            <id>56292983</id>
+            <tax_id_type>nip</tax_id_type>
+            <name>Spółdzielnia Szulc</name>
+            <nip>1234563218</nip>
+            <street>Rodzinna 15/85</street>
+            <zip>87-807</zip>
+            <city>Świdwin</city>
+            <country>PL</country>
+            <phone></phone>
+            <email></email>
+            <discount_percent>0.00</discount_percent>
+            <empty>0</empty>
+            <simple>0</simple>
+            <created>2018-01-26 15:12:56</created>
+            <modified>2018-01-26 15:12:56</modified>
+        </contractor_detail>
+        <contractor_receiver>
+            <id>0</id>
+        </contractor_receiver>
+        <contractor_detail_receiver>
+            <id>0</id>
+        </contractor_detail_receiver>
+        <company_detail>
+            <id>43890023</id>
+            <name>Daniel Bojdo Web-It</name>
+            <altname>Daniel Bojdo Web-It</altname>
+            <nip>6792775374</nip>
+            <street>ul. Christo Botewa</street>
+            <building_number>1c</building_number>
+            <flat_number></flat_number>
+            <zip>30-798</zip>
+            <post></post>
+            <city>Kraków</city>
+            <country>Polska</country>
+            <phone></phone>
+            <email></email>
+            <bank_name></bank_name>
+            <bank_account></bank_account>
+            <bank_swift></bank_swift>
+            <bank_address></bank_address>
+            <created>2018-01-26 15:12:56</created>
+            <modified>2018-01-26 15:12:56</modified>
+        </company_detail>
+        <parent>
+            <id>0</id>
+        </parent>
+        <order>
+            <id>0</id>
+        </order>
+        <email>
+            <id>0</id>
+        </email>
+        <email2>
+            <id>0</id>
+        </email2>
+        <expense>
+            <id>0</id>
+        </expense>
+        <company_account>
+            <id>0</id>
+        </company_account>
+        <payment_cashbox>
+            <id>168780</id>
+        </payment_cashbox>
+        <translation_language>
+            <id>0</id>
+        </translation_language>
+        <postivo_shipment>
+            <id>0</id>
+        </postivo_shipment>
+        <postivo_shipment_content>
+            <id>0</id>
+        </postivo_shipment_content>
+        <good_price_group>
+            <id>0</id>
+        </good_price_group>
+        <vat_contents>
+            <vat_content>
+                <id>100609496</id>
+                <object_name>Invoice</object_name>
+                <object_id>32361257</object_id>
+                <netto>3523.85</netto>
+                <tax>810.49</tax>
+                <brutto>4334.34</brutto>
+                <created>2018-01-26 15:12:56</created>
+                <vat_code>
+                    <id>222</id>
+                </vat_code>
+            </vat_content>
+        </vat_contents>
+        <invoicecontents>
+            <invoicecontent>
+                <id>122035211</id>
+                <name>DarkSlateBlue</name>
+                <classification></classification>
+                <unit>szt.</unit>
+                <count>4.0000</count>
+                <price>657.95</price>
+                <price_modified>0</price_modified>
+                <discount>1</discount>
+                <discount_percent>0.00</discount_percent>
+                <netto>2631.80</netto>
+                <brutto>3237.11</brutto>
+                <lumpcode></lumpcode>
+                <created>2018-01-26 15:12:56</created>
+                <modified>2018-01-26 15:12:56</modified>
+                <good>
+                    <id>0</id>
+                </good>
+                <invoice>
+                    <id>32361257</id>
+                </invoice>
+                <vat_code>
+                    <id>222</id>
+                </vat_code>
+                <fixed_asset>
+                    <id>0</id>
+                </fixed_asset>
+                <equipment>
+                    <id>0</id>
+                </equipment>
+                <warehouse_document_content>
+                    <id>0</id>
+                </warehouse_document_content>
+                <parent>
+                    <id>0</id>
+                </parent>
+            </invoicecontent>
+            <invoicecontent>
+                <id>122035214</id>
+                <name>Aquamarine</name>
+                <classification></classification>
+                <unit>szt.</unit>
+                <count>1.0000</count>
+                <price>892.05</price>
+                <price_modified>0</price_modified>
+                <discount>1</discount>
+                <discount_percent>0.00</discount_percent>
+                <netto>892.05</netto>
+                <brutto>1097.22</brutto>
+                <lumpcode></lumpcode>
+                <created>2018-01-26 15:12:56</created>
+                <modified>2018-01-26 15:12:56</modified>
+                <good>
+                    <id>0</id>
+                </good>
+                <invoice>
+                    <id>32361257</id>
+                </invoice>
+                <vat_code>
+                    <id>222</id>
+                </vat_code>
+                <fixed_asset>
+                    <id>0</id>
+                </fixed_asset>
+                <equipment>
+                    <id>0</id>
+                </equipment>
+                <warehouse_document_content>
+                    <id>0</id>
+                </warehouse_document_content>
+                <parent>
+                    <id>0</id>
+                </parent>
+            </invoicecontent>
+        </invoicecontents>
+    </invoice>
+    <parameters>
+        <limit>20</limit>
+        <page>1</page>
+        <total>1</total>
+    </parameters>
+</invoices>
+<status>
+    <code>OK</code>
+</status>
+</api>  {"response":"/invoices/add"} []
+        [2018-01-26 14:14:30] API.DEBUG: <?xml version="1.0" encoding="UTF-8"?> <api>
+<contractors>
+    <contractor>
+        <name>Olszewska P.P.O.F</name>
+        <tax_id_type>nip</tax_id_type>
+        <nip>1234563218</nip>
+        <street><![CDATA[Partyzantów 98A]]></street>
+        <zip>54-149</zip>
+        <city>Jawor</city>
+        <country>PL</country>
+        <different_contact_address>1</different_contact_address>
+        <contact_name>Kaczmarczyk i syn</contact_name>
+        <contact_street>Kosynierów 37</contact_street>
+        <contact_zip>53-069</contact_zip>
+        <contact_city>Chorzów</contact_city>
+        <contact_country>PL</contact_country>
+        <contact_person>mgr Artur Wieczorek</contact_person>
+        <buyer>1</buyer>
+        <seller>0</seller>
+    </contractor>
+</contractors>
+</api>  {"request":"/contractors/add"} []
+        [2018-01-26 14:14:31] API.DEBUG: <?xml version="1.0" encoding="UTF-8"?> <api>
+<contractors>
+    <contractor>
+        <id>13791025</id>
+        <tax_id_type>nip</tax_id_type>
+        <name>Olszewska P.P.O.F</name>
+        <altname>Olszewska P.P.O.F</altname>
+        <nip>1234563218</nip>
+        <regon></regon>
+        <street>Partyzantów 98A</street>
+        <zip>54-149</zip>
+        <city>Jawor</city>
+        <country>PL</country>
+        <different_contact_address>1</different_contact_address>
+        <contact_name>Kaczmarczyk i syn</contact_name>
+        <contact_street>Kosynierów 37</contact_street>
+        <contact_zip>53-069</contact_zip>
+        <contact_city>Chorzów</contact_city>
+        <contact_country>PL</contact_country>
+        <contact_person>mgr Artur Wieczorek</contact_person>
+        <phone></phone>
+        <skype></skype>
+        <fax></fax>
+        <email></email>
+        <url></url>
+        <description></description>
+        <buyer>1</buyer>
+        <seller>0</seller>
+        <discount_percent>0.00</discount_percent>
+        <payment_days>7</payment_days>
+        <payment_method></payment_method>
+        <account_number></account_number>
+        <remind>1</remind>
+        <hash>0f7e0c7c38f225f1e6f1983ad14bc723</hash>
+        <avatar_filename></avatar_filename>
+        <source>Własne</source>
+        <tags></tags>
+        <notes>0</notes>
+        <documents>0</documents>
+        <created>2018-01-26 15:12:57</created>
+        <modified>2018-01-26 15:12:57</modified>
+        <reference_company>
+            <id>0</id>
+        </reference_company>
+        <translation_language>
+            <id>0</id>
+        </translation_language>
+        <company_account>
+            <id>0</id>
+        </company_account>
+        <good_price_group>
+            <id>0</id>
+        </good_price_group>
+        <invoice_description>
+            <id>0</id>
+        </invoice_description>
+        <shop_buyer>
+            <id>0</id>
+        </shop_buyer>
+    </contractor>
+    <parameters>
+        <limit>20</limit>
+        <page>1</page>
+        <total>1</total>
+    </parameters>
+</contractors>
+<status>
+    <code>OK</code>
+</status>
+</api>  {"response":"/contractors/add"} []
+        [2018-01-26 14:14:31] API.DEBUG: <?xml version="1.0" encoding="UTF-8"?> <api>
+<invoices>
+    <invoice>
+        <contractor>
+            <id>13791025</id>
+        </contractor>
+        <paymentmethod>transfer</paymentmethod>
+        <paymentdate>2018-02-13</paymentdate>
+        <disposaldate_format>day</disposaldate_format>
+        <disposaldate_empty>0</disposaldate_empty>
+        <disposaldate><![CDATA[2018-01-26]]></disposaldate>
+        <date>2018-01-23</date>
+        <number>4</number>
+        <day>23</day>
+        <month>1</month>
+        <year>2018</year>
+        <type>normal</type>
+        <currency>PLN</currency>
+        <template>3</template>
+        <auto_send>0</auto_send>
+        <auto_send_postivo>0</auto_send_postivo>
+        <auto_sms>0</auto_sms>
+        <description><![CDATA[]]></description>
+        <schema_bill>0</schema_bill>
+        <register_description><![CDATA[]]></register_description>
+        <id_external><![CDATA[]]></id_external>
+        <price_type><![CDATA[netto]]></price_type>
+        <invoicecontents>
+            <invoicecontent>
+                <name>Aquamarine</name>
+                <classification></classification>
+                <unit>szt.</unit>
+                <count>1</count>
+                <price>892.05</price>
+                <discount>1</discount>
+                <discount_percent>0</discount_percent>
+                <discount>1</discount>
+                <discount>1</discount>
+                <lumpcode></lumpcode>
+                <good>
+                    <id>0</id>
+                </good>
+            </invoicecontent>
+            <invoicecontent>
+                <name>IndianRed</name>
+                <unit>szt.</unit>
+                <count>2</count>
+                <price>904.47</price>
+                <vat>23</vat>
+            </invoicecontent>
+        </invoicecontents>
+        <series>
+            <id>5415136</id>
+        </series>
+    </invoice>
+</invoices>
+</api>  {"request":"/invoices/edit/32361257"} []
+        [2018-01-26 14:14:32] API.DEBUG: <?xml version="1.0" encoding="UTF-8"?> <api>
+<invoices>
+    <invoice>
+        <id>32361257</id>
+        <interest_status></interest_status>
+        <warehouse_type>extended</warehouse_type>
+        <paymentmethod>transfer</paymentmethod>
+        <paymentdate>2018-02-13</paymentdate>
+        <paymentstate>unpaid</paymentstate>
+        <disposaldate_format>day</disposaldate_format>
+        <disposaldate_empty>0</disposaldate_empty>
+        <disposaldate>2018-01-26</disposaldate>
+        <date>2018-01-23</date>
+        <total>3322.22</total>
+        <total_composed>3322.22</total_composed>
+        <alreadypaid>0.00</alreadypaid>
+        <alreadypaid_initial></alreadypaid_initial>
+        <remaining>3322.22</remaining>
+        <number>4</number>
+        <day>23</day>
+        <month>1</month>
+        <year>2018</year>
+        <day_year>23</day_year>
+        <fullnumber>FV/I/Test/2018/4</fullnumber>
+        <semitemplatenumber>FV/I/Test/2018/[numer]</semitemplatenumber>
+        <type>normal</type>
+        <correction_type></correction_type>
+        <corrections>0</corrections>
+        <formal_data_corrections>0</formal_data_corrections>
+        <currency>PLN</currency>
+        <currency_exchange>1.0000</currency_exchange>
+        <currency_label></currency_label>
+        <currency_date></currency_date>
+        <price_currency_exchange>1.0000</price_currency_exchange>
+        <good_price_group_currency_exchange>1.0000</good_price_group_currency_exchange>
+        <auto_send_postivo>0</auto_send_postivo>
+        <auto_send>0</auto_send>
+        <auto_sms>0</auto_sms>
+        <account_type></account_type>
+        <account_date></account_date>
+        <template>3</template>
+        <description></description>
+        <header></header>
+        <footer></footer>
+        <user_name></user_name>
+        <schema>normal</schema>
+        <schema_vat_cashbox>0</schema_vat_cashbox>
+        <schema_vat_cashbox_limit></schema_vat_cashbox_limit>
+        <schema_vat_cashbox_small_taxpayer>0</schema_vat_cashbox_small_taxpayer>
+        <schema_bill>0</schema_bill>
+        <schema_receipt_book>0</schema_receipt_book>
+        <schema_cancelled>0</schema_cancelled>
+        <margin_tax_schema></margin_tax_schema>
+        <margin_description_schema></margin_description_schema>
+        <register_description></register_description>
+        <income_lumpcode></income_lumpcode>
+        <income_correction>0</income_correction>
+        <bill_legal_description></bill_legal_description>
+        <netto>2700.99</netto>
+        <tax>621.23</tax>
+        <receipt_fiscal_printed>0</receipt_fiscal_printed>
+        <vindicat_sent>0</vindicat_sent>
+        <invipay_sent>0</invipay_sent>
+        <courier_shipments>0</courier_shipments>
+        <hash>49d94ee5fa391adcd2d4c5dd29763c66</hash>
+        <id_external></id_external>
+        <tags></tags>
+        <notes>0</notes>
+        <documents>0</documents>
+        <created>2018-01-26 15:12:56</created>
+        <modified>2018-01-26 15:12:58</modified>
+        <price_type>netto</price_type>
+        <series>
+            <id>5415136</id>
+        </series>
+        <contractor>
+            <id>13791025</id>
+        </contractor>
+        <contractor_detail>
+            <id>56292983</id>
+            <tax_id_type>nip</tax_id_type>
+            <name>Olszewska P.P.O.F</name>
+            <nip>1234563218</nip>
+            <street>Partyzantów 98A</street>
+            <zip>54-149</zip>
+            <city>Jawor</city>
+            <country>PL</country>
+            <phone></phone>
+            <email></email>
+            <discount_percent>0.00</discount_percent>
+            <empty>0</empty>
+            <simple>0</simple>
+            <created>2018-01-26 15:12:57</created>
+            <modified>2018-01-26 15:12:57</modified>
+        </contractor_detail>
+        <contractor_receiver>
+            <id>0</id>
+        </contractor_receiver>
+        <contractor_detail_receiver>
+            <id>0</id>
+        </contractor_detail_receiver>
+        <company_detail>
+            <id>43890023</id>
+            <name>Daniel Bojdo Web-It</name>
+            <altname>Daniel Bojdo Web-It</altname>
+            <nip>6792775374</nip>
+            <street>ul. Christo Botewa</street>
+            <building_number>1c</building_number>
+            <flat_number></flat_number>
+            <zip>30-798</zip>
+            <post></post>
+            <city>Kraków</city>
+            <country>Polska</country>
+            <phone></phone>
+            <email></email>
+            <bank_name></bank_name>
+            <bank_account></bank_account>
+            <bank_swift></bank_swift>
+            <bank_address></bank_address>
+            <created>2018-01-26 15:12:56</created>
+            <modified>2018-01-26 15:12:58</modified>
+        </company_detail>
+        <parent>
+            <id>0</id>
+        </parent>
+        <order>
+            <id>0</id>
+        </order>
+        <email>
+            <id>0</id>
+        </email>
+        <email2>
+            <id>0</id>
+        </email2>
+        <expense>
+            <id>0</id>
+        </expense>
+        <company_account>
+            <id>0</id>
+        </company_account>
+        <payment_cashbox>
+            <id>168780</id>
+        </payment_cashbox>
+        <translation_language>
+            <id>0</id>
+        </translation_language>
+        <postivo_shipment>
+            <id>0</id>
+        </postivo_shipment>
+        <postivo_shipment_content>
+            <id>0</id>
+        </postivo_shipment_content>
+        <good_price_group>
+            <id>0</id>
+        </good_price_group>
+        <vat_contents>
+            <vat_content>
+                <id>100609501</id>
+                <object_name>Invoice</object_name>
+                <object_id>32361257</object_id>
+                <netto>2700.99</netto>
+                <tax>621.23</tax>
+                <brutto>3322.22</brutto>
+                <created>2018-01-26 15:12:58</created>
+                <vat_code>
+                    <id>222</id>
+                </vat_code>
+            </vat_content>
+        </vat_contents>
+        <invoicecontents>
+            <invoicecontent>
+                <id>122035216</id>
+                <name>Aquamarine</name>
+                <classification></classification>
+                <unit>szt.</unit>
+                <count>1.0000</count>
+                <price>892.05</price>
+                <price_modified>0</price_modified>
+                <discount>1</discount>
+                <discount_percent>0.00</discount_percent>
+                <netto>892.05</netto>
+                <brutto>1097.22</brutto>
+                <lumpcode></lumpcode>
+                <created>2018-01-26 15:12:58</created>
+                <modified>2018-01-26 15:12:58</modified>
+                <good>
+                    <id>0</id>
+                </good>
+                <invoice>
+                    <id>32361257</id>
+                </invoice>
+                <vat_code>
+                    <id>222</id>
+                </vat_code>
+                <fixed_asset>
+                    <id>0</id>
+                </fixed_asset>
+                <equipment>
+                    <id>0</id>
+                </equipment>
+                <warehouse_document_content>
+                    <id>0</id>
+                </warehouse_document_content>
+                <parent>
+                    <id>0</id>
+                </parent>
+            </invoicecontent>
+            <invoicecontent>
+                <id>122035219</id>
+                <name>IndianRed</name>
+                <classification></classification>
+                <unit>szt.</unit>
+                <count>2.0000</count>
+                <price>904.47</price>
+                <price_modified>0</price_modified>
+                <discount>1</discount>
+                <discount_percent>0.00</discount_percent>
+                <netto>1808.94</netto>
+                <brutto>2225.00</brutto>
+                <lumpcode></lumpcode>
+                <created>2018-01-26 15:12:58</created>
+                <modified>2018-01-26 15:12:58</modified>
+                <good>
+                    <id>0</id>
+                </good>
+                <invoice>
+                    <id>32361257</id>
+                </invoice>
+                <vat_code>
+                    <id>222</id>
+                </vat_code>
+                <fixed_asset>
+                    <id>0</id>
+                </fixed_asset>
+                <equipment>
+                    <id>0</id>
+                </equipment>
+                <warehouse_document_content>
+                    <id>0</id>
+                </warehouse_document_content>
+                <parent>
+                    <id>0</id>
+                </parent>
+            </invoicecontent>
+        </invoicecontents>
+    </invoice>
+    <parameters>
+        <limit>20</limit>
+        <page>1</page>
+        <total>1</total>
+    </parameters>
+</invoices>
+<status>
+    <code>OK</code>
+</status>
+</api>  {"response":"/invoices/edit/32361257"} []
+        [2018-01-26 14:14:32] API.DEBUG:  {"request":"/invoices/delete/32361257"} []
+        [2018-01-26 14:14:33] API.DEBUG: <?xml version="1.0" encoding="UTF-8"?> <api>
+<invoices>
+    <invoice>
+        <id>32361257</id>
+        <interest_status></interest_status>
+        <warehouse_type>extended</warehouse_type>
+        <paymentmethod>transfer</paymentmethod>
+        <paymentdate>2018-02-13</paymentdate>
+        <paymentstate>unpaid</paymentstate>
+        <disposaldate_format>day</disposaldate_format>
+        <disposaldate_empty>0</disposaldate_empty>
+        <disposaldate>2018-01-26</disposaldate>
+        <date>2018-01-23</date>
+        <total>3322.22</total>
+        <total_composed>3322.22</total_composed>
+        <alreadypaid>0.00</alreadypaid>
+        <alreadypaid_initial></alreadypaid_initial>
+        <remaining>3322.22</remaining>
+        <number>4</number>
+        <day>23</day>
+        <month>1</month>
+        <year>2018</year>
+        <day_year>23</day_year>
+        <fullnumber>FV/I/Test/2018/4</fullnumber>
+        <semitemplatenumber>FV/I/Test/2018/[numer]</semitemplatenumber>
+        <type>normal</type>
+        <correction_type></correction_type>
+        <corrections>0</corrections>
+        <formal_data_corrections>0</formal_data_corrections>
+        <currency>PLN</currency>
+        <currency_exchange>1.0000</currency_exchange>
+        <currency_label></currency_label>
+        <currency_date></currency_date>
+        <price_currency_exchange>1.0000</price_currency_exchange>
+        <good_price_group_currency_exchange>1.0000</good_price_group_currency_exchange>
+        <auto_send_postivo>0</auto_send_postivo>
+        <auto_send>0</auto_send>
+        <auto_sms>0</auto_sms>
+        <account_type></account_type>
+        <account_date></account_date>
+        <template>3</template>
+        <description></description>
+        <header></header>
+        <footer></footer>
+        <user_name></user_name>
+        <schema>normal</schema>
+        <schema_vat_cashbox>0</schema_vat_cashbox>
+        <schema_vat_cashbox_limit></schema_vat_cashbox_limit>
+        <schema_vat_cashbox_small_taxpayer>0</schema_vat_cashbox_small_taxpayer>
+        <schema_bill>0</schema_bill>
+        <schema_receipt_book>0</schema_receipt_book>
+        <schema_cancelled>0</schema_cancelled>
+        <margin_tax_schema></margin_tax_schema>
+        <margin_description_schema></margin_description_schema>
+        <register_description></register_description>
+        <income_lumpcode></income_lumpcode>
+        <income_correction>0</income_correction>
+        <bill_legal_description></bill_legal_description>
+        <netto>2700.99</netto>
+        <tax>621.23</tax>
+        <receipt_fiscal_printed>0</receipt_fiscal_printed>
+        <vindicat_sent>0</vindicat_sent>
+        <invipay_sent>0</invipay_sent>
+        <courier_shipments>0</courier_shipments>
+        <hash>49d94ee5fa391adcd2d4c5dd29763c66</hash>
+        <id_external></id_external>
+        <tags></tags>
+        <notes>0</notes>
+        <documents>0</documents>
+        <created>2018-01-26 15:12:56</created>
+        <modified>2018-01-26 15:12:58</modified>
+        <price_type>netto</price_type>
+        <series>
+            <id>5415136</id>
+        </series>
+        <contractor>
+            <id>13791025</id>
+        </contractor>
+        <contractor_detail>
+            <id>56292983</id>
+            <tax_id_type>nip</tax_id_type>
+            <name>Olszewska P.P.O.F</name>
+            <nip>1234563218</nip>
+            <street>Partyzantów 98A</street>
+            <zip>54-149</zip>
+            <city>Jawor</city>
+            <country>PL</country>
+            <phone></phone>
+            <email></email>
+            <discount_percent>0.00</discount_percent>
+            <empty>0</empty>
+            <simple>0</simple>
+            <created>2018-01-26 15:12:57</created>
+            <modified>2018-01-26 15:12:57</modified>
+        </contractor_detail>
+        <contractor_receiver>
+            <id>0</id>
+        </contractor_receiver>
+        <contractor_detail_receiver>
+            <id>0</id>
+        </contractor_detail_receiver>
+        <company_detail>
+            <id>43890023</id>
+            <name>Daniel Bojdo Web-It</name>
+            <altname>Daniel Bojdo Web-It</altname>
+            <nip>6792775374</nip>
+            <street>ul. Christo Botewa</street>
+            <building_number>1c</building_number>
+            <flat_number></flat_number>
+            <zip>30-798</zip>
+            <post></post>
+            <city>Kraków</city>
+            <country>Polska</country>
+            <phone></phone>
+            <email></email>
+            <bank_name></bank_name>
+            <bank_account></bank_account>
+            <bank_swift></bank_swift>
+            <bank_address></bank_address>
+            <created>2018-01-26 15:12:56</created>
+            <modified>2018-01-26 15:12:58</modified>
+        </company_detail>
+        <parent>
+            <id>0</id>
+        </parent>
+        <order>
+            <id>0</id>
+        </order>
+        <email>
+            <id>0</id>
+        </email>
+        <email2>
+            <id>0</id>
+        </email2>
+        <expense>
+            <id>0</id>
+        </expense>
+        <company_account>
+            <id>0</id>
+        </company_account>
+        <payment_cashbox>
+            <id>168780</id>
+        </payment_cashbox>
+        <translation_language>
+            <id>0</id>
+        </translation_language>
+        <postivo_shipment>
+            <id>0</id>
+        </postivo_shipment>
+        <postivo_shipment_content>
+            <id>0</id>
+        </postivo_shipment_content>
+        <good_price_group>
+            <id>0</id>
+        </good_price_group>
+        <vat_contents>
+            <vat_content>
+                <id>100609501</id>
+                <object_name>Invoice</object_name>
+                <object_id>32361257</object_id>
+                <netto>2700.99</netto>
+                <tax>621.23</tax>
+                <brutto>3322.22</brutto>
+                <created>2018-01-26 15:12:58</created>
+                <vat_code>
+                    <id>222</id>
+                </vat_code>
+            </vat_content>
+        </vat_contents>
+        <invoicecontents>
+            <invoicecontent>
+                <id>122035216</id>
+                <name>Aquamarine</name>
+                <classification></classification>
+                <unit>szt.</unit>
+                <count>1.0000</count>
+                <price>892.05</price>
+                <price_modified>0</price_modified>
+                <discount>1</discount>
+                <discount_percent>0.00</discount_percent>
+                <netto>892.05</netto>
+                <brutto>1097.22</brutto>
+                <lumpcode></lumpcode>
+                <created>2018-01-26 15:12:58</created>
+                <modified>2018-01-26 15:12:58</modified>
+                <good>
+                    <id>0</id>
+                </good>
+                <invoice>
+                    <id>32361257</id>
+                </invoice>
+                <vat_code>
+                    <id>222</id>
+                </vat_code>
+                <fixed_asset>
+                    <id>0</id>
+                </fixed_asset>
+                <equipment>
+                    <id>0</id>
+                </equipment>
+                <warehouse_document_content>
+                    <id>0</id>
+                </warehouse_document_content>
+                <parent>
+                    <id>0</id>
+                </parent>
+            </invoicecontent>
+            <invoicecontent>
+                <id>122035219</id>
+                <name>IndianRed</name>
+                <classification></classification>
+                <unit>szt.</unit>
+                <count>2.0000</count>
+                <price>904.47</price>
+                <price_modified>0</price_modified>
+                <discount>1</discount>
+                <discount_percent>0.00</discount_percent>
+                <netto>1808.94</netto>
+                <brutto>2225.00</brutto>
+                <lumpcode></lumpcode>
+                <created>2018-01-26 15:12:58</created>
+                <modified>2018-01-26 15:12:58</modified>
+                <good>
+                    <id>0</id>
+                </good>
+                <invoice>
+                    <id>32361257</id>
+                </invoice>
+                <vat_code>
+                    <id>222</id>
+                </vat_code>
+                <fixed_asset>
+                    <id>0</id>
+                </fixed_asset>
+                <equipment>
+                    <id>0</id>
+                </equipment>
+                <warehouse_document_content>
+                    <id>0</id>
+                </warehouse_document_content>
+                <parent>
+                    <id>0</id>
+                </parent>
+            </invoicecontent>
+        </invoicecontents>
+    </invoice>
+    <parameters>
+        <limit>20</limit>
+        <page>1</page>
+        <total>1</total>
+    </parameters>
+</invoices>
+<status>
+    <code>OK</code>
+    <message>Faktura FV/I/Test/2018/4 została usunięta.</message>
+</status>
+</api>


### PR DESCRIPTION
These commits:
- make some changes to prepare for payments API (i.e. move PaymentMethod from Invoices to Payments namespace),
- fix Invoice::changePayment method to return Invoice (as other change* methods do),
- add PaymentsApi / Payment classes,
- expose undocumented type_of_sale field in invoices API (used for setting GTU codes "EE" and "SW" on the Invoice).

I have not yet tested if payment can indeed be added from scratch, only edits were tested up to date.