### PR TITLE
Fix PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "keywords": ["sdk", "api", "wfirma", "w-firma"],
     "require": {
-        "php": ">=7.1",
+        "php": "^8.0",
         "jms/serializer": "^1.0.0|^2.0.0|^3.0.0",
         "kriswallsmith/buzz": "^1.0.0",
         "nyholm/psr7": "^1.0.0",

--- a/src/Entity/EntityIterator.php
+++ b/src/Entity/EntityIterator.php
@@ -34,7 +34,7 @@ final class EntityIterator implements \Iterator
     /**
      * @inheritdoc
      */
-    public function current()
+    public function current(): mixed
     {
         if (!isset($this->currentBatch[$this->batchIndex])) {
             $this->loadNextBatch(true);
@@ -46,7 +46,7 @@ final class EntityIterator implements \Iterator
     /**
      * @inheritdoc
      */
-    public function next()
+    public function next(): void
     {
         $this->batchIndex++;
         $this->totalIndex++;
@@ -55,7 +55,7 @@ final class EntityIterator implements \Iterator
     /**
      * @inheritdoc
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->totalIndex;
     }
@@ -63,7 +63,7 @@ final class EntityIterator implements \Iterator
     /**
      * @inheritdoc
      */
-    public function valid()
+    public function valid(): bool
     {
         if ($this->totalCount === null) {
             $this->totalCount = $this->entityApi->count($this->request->module(), $this->request->parameters());
@@ -75,7 +75,7 @@ final class EntityIterator implements \Iterator
     /**
      * @inheritdoc
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->currentBatch = null;
         $this->batchIndex = 0;


### PR DESCRIPTION
Po aktualizacji do PHP 8.1 w logach pojawiły się tego typu warningi:

`Return type of Webit\WFirmaSDK\Entity\EntityIterator::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/webit/w-firma-api/src/Entity/EntityIterator.php on line 78`

Ten PR powinien je usunąć.