### PR TITLE
Harmonize composer.json and update required versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
     "license": "MIT",
     "keywords": ["sdk", "api", "wfirma", "w-firma"],
     "require": {
-        "php": ">=7.1",
-        "jms/serializer": "^1.0.0|^2.0.0|^3.0.0",
-        "kriswallsmith/buzz": "^1.0.0",
-        "nyholm/psr7": "^1.0.0",
-        "psr/log": "^1.0.2 || ^2.0 || ^3.0",
-        "psr/simple-cache": "^1.0.1"
+        "php": "^8.0",
+        "jms/serializer": "^1.0|^2.0|^3.0",
+        "kriswallsmith/buzz": "^1.2",
+        "nyholm/psr7": "^1.0",
+        "psr/log": "^2.0|^3.0",
+        "psr/simple-cache": "^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.3.2",


### PR DESCRIPTION
Minimalna wersja PHP 8.0 dla `webit/w-firma-api` wymaga aktualizacji obowiązkowych dependencji.

- `kriswallsmith/buzz` - minimum `1.2.0`
- `psr/log` - minimum `2.0`
- `psr/simple-cache` - minimum `2.0`

Ponadto: ujednolicono plik `composer.json` skracając numery wersji i używając w każdym przypadku pojedynczego "pipe" (`|`) do definiowania wielokrotnych dozwolonych wersji dla zależności.