### PR TITLE
Update composer requirements after jms changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": ">=7.1",
         "jms/serializer": "^1.0.0|^2.0.0|^3.0.0",
+        "doctrine/annotations": "^1.14 || ^2.0",
         "kriswallsmith/buzz": "^1.0.0",
         "nyholm/psr7": "^1.0.0",
         "psr/log": "^1.0.2 || ^2.0 || ^3.0",


### PR DESCRIPTION
Add doctrine/annotations to composer require.

jms/serializer 3.30.0
> Starting from this release doctrine/annotations is an optional package.
> If you still want to use them, please make sure that you require in composer.json file.
> 
> We strongly recommend to start using Attributes with PHP 8.

More:
https://github.com/schmittjoh/serializer/releases/tag/3.30.0