### PR TITLE
Upgrade PHP 8.1-8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "kriswallsmith/buzz": "^1.2",
         "nyholm/psr7": "^1.0",
         "psr/log": "^2.0|^3.0",
-        "psr/simple-cache": "^2.0|^3.0"
+        "psr/simple-cache": "^2.0|^3.0",
+        "doctrine/annotations": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",
-        "monolog/monolog": "^2.0",
+        "monolog/monolog": "^3.0",
         "nette/php-generator": "^3.5.4",
         "fakerphp/faker": "^1.20.0",
         "phpspec/prophecy": "^1.20",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "keywords": ["sdk", "api", "wfirma", "w-firma"],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1 || ^8.2 || ^8.3",
         "jms/serializer": "^1.0|^2.0|^3.0",
         "kriswallsmith/buzz": "^1.2",
         "nyholm/psr7": "^1.0",
@@ -13,10 +13,12 @@
         "psr/simple-cache": "^2.0|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.3.2",
-        "monolog/monolog": "^1.10.0",
+        "phpunit/phpunit": "^10.0",
+        "monolog/monolog": "^2.0",
         "nette/php-generator": "^3.5.4",
-        "fakerphp/faker": "^1.17.0"
+        "fakerphp/faker": "^1.20.0",
+        "phpspec/prophecy": "^1.20",
+        "phpspec/prophecy-phpunit": "^2.3"
     },
     "suggest": {
         "symfony/cache": "To use VatCodeIdResolver with caching feature"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "phpunit/phpunit": "^10.0",
         "monolog/monolog": "^3.0",
-        "nette/php-generator": "^3.5.4",
+        "nette/php-generator": "^4.0",
         "fakerphp/faker": "^1.20.0",
         "phpspec/prophecy": "^1.20",
         "phpspec/prophecy-phpunit": "^2.3"

--- a/src/Tags/TagIds.php
+++ b/src/Tags/TagIds.php
@@ -73,7 +73,7 @@ final class TagIds implements \IteratorAggregate, \Countable
     /**
      * @inheritdoc
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->ids());
     }
@@ -101,7 +101,7 @@ final class TagIds implements \IteratorAggregate, \Countable
     /**
      * @inheritdoc
      */
-    public function count()
+    public function count(): int
     {
         $ids = $this->ids();
 

--- a/tests/Contractors/ContractorsApiIntegrationTest.php
+++ b/tests/Contractors/ContractorsApiIntegrationTest.php
@@ -16,12 +16,12 @@ class ContractorsApiIntegrationTest extends AbstractApiTestCase
     /** @var Contractor[] */
     private $contractors = array();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->api = new ContractorsApi($this->entityApi());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach ($this->contractors as $contractor) {
             $this->api->delete($contractor->id());

--- a/tests/DeclarationCountries/DeclarationCountriesApiTest.php
+++ b/tests/DeclarationCountries/DeclarationCountriesApiTest.php
@@ -11,7 +11,7 @@ class DeclarationCountriesApiTest extends AbstractApiTestCase
      */
     private $declarationCountriesApi;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->declarationCountriesApi = new DeclarationCountriesApi(
             $this->entityApi()

--- a/tests/Entity/Infrastructure/Buzz/BuzzRequestExecutorIntegrationTest.php
+++ b/tests/Entity/Infrastructure/Buzz/BuzzRequestExecutorIntegrationTest.php
@@ -27,12 +27,12 @@ class BuzzRequestExecutorIntegrationTest extends AbstractApiTestCase
      */
     private $series = array();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->entityApi = $this->entityApi();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->series as $series) {
             try {

--- a/tests/Entity/Parameters/ParametersSerializerTest.php
+++ b/tests/Entity/Parameters/ParametersSerializerTest.php
@@ -12,7 +12,7 @@ class ParametersSerializerTest extends AbstractTestCase
     /** @var SerializerInterface */
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->serializer = $this->jmsSerializer();
     }

--- a/tests/Invoices/InvoicesApiIntegrationTest.php
+++ b/tests/Invoices/InvoicesApiIntegrationTest.php
@@ -26,12 +26,12 @@ class InvoicesApiIntegrationTest extends AbstractApiTestCase
     /** @var Contractor[] */
     private $contractors = array();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->api = $this->invoicesApi();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->invoices as $invoice) {
             $this->api->delete($invoice->id());

--- a/tests/Payments/PaymentsApiIntegrationTest.php
+++ b/tests/Payments/PaymentsApiIntegrationTest.php
@@ -22,12 +22,12 @@ class PaymentsApiIntegrationTest extends AbstractApiTestCase
     /** @var Invoice[] */
     private $invoices = array();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->api = new PaymentsApi($this->entityApi());
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach($this->payments as $payment) {
             $this->api->delete($payment->id());

--- a/tests/Tags/TagIdsTest.php
+++ b/tests/Tags/TagIdsTest.php
@@ -11,7 +11,7 @@ class TagIdsTest extends AbstractTestCase
     /** @var SerializerInterface */
     private $serialiser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->serialiser = $this->jmsSerializer();
     }

--- a/tests/TranslationLanguages/TranslationLanguagesApiIntegrationTest.php
+++ b/tests/TranslationLanguages/TranslationLanguagesApiIntegrationTest.php
@@ -11,7 +11,7 @@ class TranslationLanguagesApiIntegrationTest extends AbstractApiTestCase
     /** @var TranslationLanguagesApi */
     private $api;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->api = new TranslationLanguagesApi($this->entityApi());
     }

--- a/tests/Vat/Repository/VatCodeIdCachingMapProviderTest.php
+++ b/tests/Vat/Repository/VatCodeIdCachingMapProviderTest.php
@@ -6,9 +6,12 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\SimpleCache\CacheInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class VatCodeIdCachingMapProviderTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var VatCodeIdMapProvider|ObjectProphecy */
     private $innerProvider;
 
@@ -18,7 +21,7 @@ class VatCodeIdCachingMapProviderTest extends TestCase
     /** @var VatCodeIdCachingMapProvider */
     private $provider;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->innerProvider = $this->prophesize(VatCodeIdMapProvider::class);
         $this->cache = $this->prophesize(CacheInterface::class);

--- a/tests/Vat/Repository/VatCodeIdRepositoryFactoryTest.php
+++ b/tests/Vat/Repository/VatCodeIdRepositoryFactoryTest.php
@@ -8,9 +8,12 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Psr\SimpleCache\CacheInterface;
 use Webit\WFirmaSDK\Vat\VatCodeId;
 use Webit\WFirmaSDK\Vat\VatCodesApi;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class VatCodeIdRepositoryFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/tests/Vat/Repository/VatCodeIdRepositoryTest.php
+++ b/tests/Vat/Repository/VatCodeIdRepositoryTest.php
@@ -16,7 +16,7 @@ class VatCodeIdRepositoryTest extends TestCase
     /** @var VatCodeIdRepository */
     private $repository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->repository = new VatCodeIdRepository(self::CODE_MAP);
     }

--- a/tests/Vat/VatCodesApiIntegrationTest.php
+++ b/tests/Vat/VatCodesApiIntegrationTest.php
@@ -9,7 +9,7 @@ class VatCodesApiIntegrationTest extends AbstractApiTestCase
     /** @var VatCodesApi */
     private $vatCodesApi;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->vatCodesApi = new VatCodesApi($this->entityApi());
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,3 @@
 <?php
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
-$loader = include __DIR__.'/../vendor/autoload.php';
-
-AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Aktualizacja:
- minimalna wersja PHP to 8.1,
- dodano wsparcie dla PHP 8.1, 8.2 i 8.3,
- naprawiono deprecated warnings dla PHP 8.3,
- dodano wymaganą zależność doctrine/annotations w wersji ^2.0.
