### PR TITLE
Fix Note serialization: broken SerializedName, Groups syntax, and object_name value

### DIFF
--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -15,7 +15,7 @@ final class Note extends DateAwareEntity
      * @var string
      * @JMS\Type("string")
      * @JMS\SerializedName("object_name")
-     * @JMS\Groups("response", "addRequest")
+     * @JMS\Groups({"response", "addRequest"})
      */
     private $objectName;
 
@@ -23,15 +23,15 @@ final class Note extends DateAwareEntity
      * @var int
      * @JMS\Type("integer")
      * @JMS\SerializedName("object_id")
-     * @JMS\Groups("response", "addRequest")
+     * @JMS\Groups({"response", "addRequest"})
      */
     private $objectId;
 
     /**
      * @var string
      * @JMS\Type("string")
-     * @JMS\SerializedName("object_name")
-     * @JMS\Groups("response", "request")
+     * @JMS\SerializedName("text")
+     * @JMS\Groups({"response", "request"})
      */
     private $text;
 
@@ -42,7 +42,7 @@ final class Note extends DateAwareEntity
      */
     public function __construct(Module $module, $objectId, $text)
     {
-        $this->objectName = (string)$module;
+        $this->objectName = $module->entityName();
         $this->objectId = $objectId;
         $this->text = $text;
     }


### PR DESCRIPTION
Three bugs prevented Note from being correctly serialized/deserialized:

1. $text had @SerializedName("object_name") instead of "text" (copy-paste error), colliding with the actual $objectName property
2. @Groups annotations were missing curly braces (e.g. @Groups("a", "b") instead of @Groups({"a", "b"})), so JMS Serializer did not register them as arrays
3. Constructor used (string)$module (plural: "invoices") for object_name, but the wFirma API expects the singular entity name ("invoice") — fixed to use $module->entityName()