### PR TITLE
Invoice: expose vat_contents summary + per-line vat_code/tax (3.1.0)

### DIFF
--- a/src/Invoices/Invoice.php
+++ b/src/Invoices/Invoice.php
@@ -548,6 +548,15 @@ final class Invoice extends DateAwareEntity
     private $invoiceContents;
 
     /**
+     * @var \Webit\WFirmaSDK\Vat\VatContent[]
+     * @JMS\SerializedName("vat_contents")
+     * @JMS\Type("array<Webit\WFirmaSDK\Vat\VatContent>")
+     * @JMS\XmlList(entry="vat_content")
+     * @JMS\Groups({"response"})
+     */
+    private $vatContents;
+
+    /**
      * @var SeriesId
      * @JMS\SerializedName("series")
      * @JMS\Type("Webit\WFirmaSDK\Series\SeriesId")
@@ -649,6 +658,7 @@ final class Invoice extends DateAwareEntity
         $this->tags = $tags;
         $this->priceType = (string)$priceType;
         $this->invoiceContents = array();
+        $this->vatContents = array();
         $this->seriesId = $seriesId;
         $this->companyAccountId = $companyAccountId;
         $this->translationLanguageId = $translationLanguageId;
@@ -1143,6 +1153,14 @@ final class Invoice extends DateAwareEntity
     public function invoiceContents()
     {
         return $this->invoiceContents;
+    }
+
+    /**
+     * @return \Webit\WFirmaSDK\Vat\VatContent[]
+     */
+    public function vatContents()
+    {
+        return $this->vatContents ?: array();
     }
 
     /**

--- a/src/Invoices/InvoicesContent.php
+++ b/src/Invoices/InvoicesContent.php
@@ -93,6 +93,14 @@ final class InvoicesContent extends DateAwareEntity
     private $brutto;
 
     /**
+     * @var float
+     * @JMS\Type("double")
+     * @JMS\SerializedName("tax")
+     * @JMS\Groups({"response"})
+     */
+    private $tax;
+
+    /**
      * @var string
      * @JMS\Type("string")
      * @JMS\SerializedName("vat")
@@ -304,6 +312,22 @@ final class InvoicesContent extends DateAwareEntity
     public function brutto()
     {
         return $this->brutto;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function tax()
+    {
+        return $this->tax;
+    }
+
+    /**
+     * @return VatCodeId|null
+     */
+    public function vatCodeId(): ?VatCodeId
+    {
+        return $this->vatCodeId;
     }
 
     /**

--- a/src/Vat/VatContent.php
+++ b/src/Vat/VatContent.php
@@ -28,8 +28,8 @@ final class VatContent extends DateAwareEntity
 
     /**
      * @var VatCodeId
-     * @JMS\Type("\Webit\WFirmaSDK\Vat\VatCodeId")
-     * @JMS\SerializedName("modified")
+     * @JMS\Type("Webit\WFirmaSDK\Vat\VatCodeId")
+     * @JMS\SerializedName("vat_code")
      * @JMS\Groups({"request", "response"})
      */
     private $vatCodeId;

--- a/tests/Invoices/InvoiceSerialisationTest.php
+++ b/tests/Invoices/InvoiceSerialisationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Webit\WFirmaSDK\Invoices;
+
+use Webit\WFirmaSDK\AbstractSerialisationTest;
+use Webit\WFirmaSDK\Module;
+use Webit\WFirmaSDK\Vat\VatContent;
+
+class InvoiceSerialisationTest extends AbstractSerialisationTest
+{
+    /**
+     * @inheritdoc
+     */
+    protected function module()
+    {
+        return Module::invoices();
+    }
+
+    /**
+     * @test
+     */
+    public function it_deserialises_vat_contents()
+    {
+        /** @var Invoice $invoice */
+        $invoice = $this->deserialiseEntity($this->invoiceXml());
+
+        $vatContents = $invoice->vatContents();
+        $this->assertIsArray($vatContents);
+        $this->assertCount(2, $vatContents);
+
+        $first = $vatContents[0];
+        $this->assertInstanceOf(VatContent::class, $first);
+        $this->assertSame(100.00, $first->netto());
+        $this->assertSame(23.00, $first->tax());
+        $this->assertSame(123.00, $first->brutto());
+        $this->assertSame(17, $first->vatCodeId()->id());
+
+        $second = $vatContents[1];
+        $this->assertSame(50.00, $second->netto());
+        $this->assertSame(0.00, $second->tax());
+        $this->assertSame(50.00, $second->brutto());
+        $this->assertSame(28, $second->vatCodeId()->id());
+    }
+
+    /**
+     * @test
+     */
+    public function it_deserialises_per_line_tax_and_vat_code_id()
+    {
+        /** @var Invoice $invoice */
+        $invoice = $this->deserialiseEntity($this->invoiceXml());
+
+        $contents = $invoice->invoiceContents();
+        $this->assertCount(1, $contents);
+
+        $line = $contents[0];
+        $this->assertSame(100.00, $line->netto());
+        $this->assertSame(123.00, $line->brutto());
+        $this->assertSame(23.00, $line->tax());
+        $this->assertEquals(10.00, $line->discount()->percent());
+        $this->assertSame(17, $line->vatCodeId()->id());
+    }
+
+    private function invoiceXml(): string
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice>
+    <id>123</id>
+    <total>173.00</total>
+    <netto>150.00</netto>
+    <tax>23.00</tax>
+    <invoicecontents>
+        <invoicecontent>
+            <id>1</id>
+            <name>Service</name>
+            <count>1</count>
+            <price>100.00</price>
+            <discount_percent>10.00</discount_percent>
+            <netto>100.00</netto>
+            <brutto>123.00</brutto>
+            <tax>23.00</tax>
+            <vat_code>
+                <id>17</id>
+            </vat_code>
+        </invoicecontent>
+    </invoicecontents>
+    <vat_contents>
+        <vat_content>
+            <id>10</id>
+            <netto>100.00</netto>
+            <tax>23.00</tax>
+            <brutto>123.00</brutto>
+            <vat_code>
+                <id>17</id>
+            </vat_code>
+        </vat_content>
+        <vat_content>
+            <id>11</id>
+            <netto>50.00</netto>
+            <tax>0.00</tax>
+            <brutto>50.00</brutto>
+            <vat_code>
+                <id>28</id>
+            </vat_code>
+        </vat_content>
+    </vat_contents>
+</invoice>
+XML;
+    }
+}


### PR DESCRIPTION
## Podsumowanie

Dodaje brakujące ścieżki odczytu, dzięki którym pobrana faktura (`invoices/get` / `InvoicesApi::get()`) udostępnia dane, które warstwa encji wcześniej gubiła — bez potrzeby parsowania surowego JSON-a po stronie konsumenta.

1. **`Invoice::vatContents()`** — podsumowanie per stawka VAT (`vat_contents`), po jednym `Webit\WFirmaSDK\Vat\VatContent` na stawkę; każdy udostępnia `netto()`, `tax()`, `brutto()` oraz `vatCodeId()` (zwraca `VatCodeId`, numeryczne id przez `->id()`). Wcześniej ta kolekcja była po cichu pomijana przy deserializacji.
2. **`InvoicesContent::tax()`** oraz **`InvoicesContent::vatCodeId(): ?VatCodeId`** na każdej linii faktury.

Wszystkie zmiany są addytywne i wstecznie kompatybilne.

## Naprawiony błąd (wymagany do punktu 1)

`Webit\WFirmaSDK\Vat\VatContent::$vatCodeId` miało adnotację `@JMS\SerializedName("modified")` oraz typ z wiodącym backslashem, przez co element `vat_code` nigdy nie mapował się na `VatCodeId`. Poprawione na `@JMS\SerializedName("vat_code")` z poprawnym typem.

## Kształt danych

**XML** (`invoices/get`):

```xml
<invoice>
  <invoicecontents>
    <invoicecontent>
      <netto>1.00</netto><brutto>1.23</brutto>
      <vat_code><id>222</id></vat_code>
    </invoicecontent>
  </invoicecontents>
  <vat_contents>
    <vat_content>
      <netto>1.00</netto><tax>0.23</tax><brutto>1.23</brutto>
      <vat_code><id>222</id></vat_code>
    </vat_content>
  </vat_contents>
</invoice>
```

## Nowe akcesory (kontrakt integracyjny)

- `Invoice::vatContents(): VatContent[]`
- `VatContent::netto()/tax()/brutto()/vatCodeId()` (naprawione mapowanie `vat_code`)
- `InvoicesContent::tax(): ?float`
- `InvoicesContent::vatCodeId(): ?VatCodeId`

## Weryfikacja na żywym API

Sprawdzone `vat_contents` na realnych fakturach wielostawkowych: faktura z 4 stawkami (23% / 8% / 0% / zw) zwraca wszystkie cztery wiersze `VatContent` z poprawnymi `netto`/`tax`/`brutto` i id `vat_code`.

**Uwaga o per-linii `tax`:** akcesor mapuje `<tax>`, jeśli jest obecne, ale `invoices/get` **nie** zwraca elementu `tax` wewnątrz `invoicecontent` (per linia są tylko `netto`/`brutto`/`vat_code`; podatek jest na poziomie nagłówka faktury oraz w `vat_contents`). Po podatek per stawka należy używać `vatContents()`.

## Testy / kompatybilność

- Nowy `tests/Invoices/InvoiceSerialisationTest.php` (deserializacja XML dla `vat_contents` oraz per-linii `tax`/`vat_code`, wyłącznie na fixture'ach — bez sieci).
- Pełny suite zielony na **PHP 8.5**
